### PR TITLE
Fix bug that caused output files to be overwritten

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -148,7 +148,7 @@ class Main {
 		// Step 3: Use haxe.macro.Printer to print the Haxe declarations.
 		var printer = new haxe.macro.Printer();
 		for (k in converter.modules.keys()) {
-			var outPath = outDir + "/" + tshx.Converter.capitalize(k.replace("/", "_")) + ".hx";
+			var outPath = outDir + "/" + k.replace("/", "_") + ".hx";
 			var buf = new StringBuf();
 			for (t in converter.modules[k].types) {
 				var s = printer.printTypeDefinition(t);

--- a/src/tshx/Converter.hx
+++ b/src/tshx/Converter.hx
@@ -84,7 +84,7 @@ class Converter {
 	}
 
 	function convertModule(m:TsModule) {
-		var name = pathToString(m.path);
+		var name = capitalize(pathToString(m.path));
 		if (!modules.exists(name)) {
 			modules[name] = {
 				types: [],
@@ -99,7 +99,7 @@ class Converter {
 		if (modules[name].toplevel.length > 0) {
 			modules[name].types.push({
 				pack: [],
-				name: capitalize(name.replace("/", "_")) + "TopLevel",
+				name: name.replace("/", "_") + "TopLevel",
 				pos: nullPos,
 				isExtern: true,
 				kind: TDClass(),


### PR DESCRIPTION
This pull request fixes the following bug:

When converting a TypeScript file that contains:
 - a TypeScript module of the same name as the file, but with different casing; and
 - at least one top-level declaration in addition to the module;

the Converter would store this as two separate "modules" in the Converter.modules variable:
 - one with the same casing as the TypeScript module, and containing the contents of the TypeScript module; and
 - one with the same casing as the file, and containing the additional top-level declarations.

The two modules would go on to be written to the same filename, resulting in the second module overwriting the first.

An example of a TypeScript file that causes this bug is: https://github.com/borisyankov/DefinitelyTyped/blob/b3aeee64552e324581fdbe0926f4a96e981e451b/ractive/ractive.d.ts (due to the top-level declaration on line 476).